### PR TITLE
planner - make it more fancy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,53 +511,53 @@ target_link_libraries(ostpolar PRIVATE
 )
 target_compile_definitions(ostpolar PRIVATE POLAR_MODULE)
 
-# Parkmanager module
-add_library(ostparkmanager SHARED
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.qrc
-)
-target_link_libraries(ostparkmanager PRIVATE
-    ostindimodule
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Concurrent
-    Qt${QT_VERSION_MAJOR}::Widgets
-    Threads::Threads
-    z
-)
-target_compile_definitions(ostparkmanager PRIVATE PARKMANAGER_MODULE)
-
-# Monitor module
-add_library(ostmonitor SHARED
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.qrc
-)
-target_link_libraries(ostmonitor PRIVATE
-    ostindimodule
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Concurrent
-    Qt${QT_VERSION_MAJOR}::Widgets
-    Threads::Threads
-    z
-)
-target_compile_definitions(ostmonitor PRIVATE MONITOR_MODULE)
-
-# Meteo module
-add_library(ostmeteo SHARED
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.qrc
-)
-target_link_libraries(ostmeteo PRIVATE
-    ostindimodule
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Concurrent
-    Qt${QT_VERSION_MAJOR}::Widgets
-    Threads::Threads
-    z
-)
-target_compile_definitions(ostmeteo PRIVATE METEO_MODULE)
+## Parkmanager module
+#add_library(ostparkmanager SHARED
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.h
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.cpp
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.qrc
+#)
+#target_link_libraries(ostparkmanager PRIVATE
+#    ostindimodule
+#    Qt${QT_VERSION_MAJOR}::Core
+#    Qt${QT_VERSION_MAJOR}::Concurrent
+#    Qt${QT_VERSION_MAJOR}::Widgets
+#    Threads::Threads
+#    z
+#)
+#target_compile_definitions(ostparkmanager PRIVATE PARKMANAGER_MODULE)
+#
+### Monitor module
+#add_library(ostmonitor SHARED
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.h
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.cpp
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.qrc
+#)
+#target_link_libraries(ostmonitor PRIVATE
+#    ostindimodule
+#    Qt${QT_VERSION_MAJOR}::Core
+#    Qt${QT_VERSION_MAJOR}::Concurrent
+#    Qt${QT_VERSION_MAJOR}::Widgets
+#    Threads::Threads
+#    z
+#)
+#target_compile_definitions(ostmonitor PRIVATE MONITOR_MODULE)
+#
+## Meteo module
+#add_library(ostmeteo SHARED
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.h
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.cpp
+#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.qrc
+#)
+#target_link_libraries(ostmeteo PRIVATE
+#    ostindimodule
+#    Qt${QT_VERSION_MAJOR}::Core
+#    Qt${QT_VERSION_MAJOR}::Concurrent
+#    Qt${QT_VERSION_MAJOR}::Widgets
+#    Threads::Threads
+#    z
+#)
+#target_compile_definitions(ostmeteo PRIVATE METEO_MODULE)
 
 install(TARGETS
     ostserver
@@ -571,9 +571,9 @@ install(TARGETS
     ostallsky
     ostplanner
     ostpolar
-    ostparkmanager
-    ostmonitor
-    ostmeteo
+#    ostparkmanager
+#    ostmonitor
+#    ostmeteo
     RUNTIME DESTINATION "/usr/bin"     COMPONENT Runtime
     LIBRARY DESTINATION "/usr/lib"     COMPONENT Runtime
     PUBLIC_HEADER DESTINATION "/usr/include/ost" COMPONENT Development

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,53 +511,53 @@ target_link_libraries(ostpolar PRIVATE
 )
 target_compile_definitions(ostpolar PRIVATE POLAR_MODULE)
 
-## Parkmanager module
-#add_library(ostparkmanager SHARED
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.h
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.cpp
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.qrc
-#)
-#target_link_libraries(ostparkmanager PRIVATE
-#    ostindimodule
-#    Qt${QT_VERSION_MAJOR}::Core
-#    Qt${QT_VERSION_MAJOR}::Concurrent
-#    Qt${QT_VERSION_MAJOR}::Widgets
-#    Threads::Threads
-#    z
-#)
-#target_compile_definitions(ostparkmanager PRIVATE PARKMANAGER_MODULE)
-#
-### Monitor module
-#add_library(ostmonitor SHARED
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.h
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.cpp
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.qrc
-#)
-#target_link_libraries(ostmonitor PRIVATE
-#    ostindimodule
-#    Qt${QT_VERSION_MAJOR}::Core
-#    Qt${QT_VERSION_MAJOR}::Concurrent
-#    Qt${QT_VERSION_MAJOR}::Widgets
-#    Threads::Threads
-#    z
-#)
-#target_compile_definitions(ostmonitor PRIVATE MONITOR_MODULE)
-#
-## Meteo module
-#add_library(ostmeteo SHARED
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.h
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.cpp
-#    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.qrc
-#)
-#target_link_libraries(ostmeteo PRIVATE
-#    ostindimodule
-#    Qt${QT_VERSION_MAJOR}::Core
-#    Qt${QT_VERSION_MAJOR}::Concurrent
-#    Qt${QT_VERSION_MAJOR}::Widgets
-#    Threads::Threads
-#    z
-#)
-#target_compile_definitions(ostmeteo PRIVATE METEO_MODULE)
+# Parkmanager module
+add_library(ostparkmanager SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/parkmanager/parkmanager.qrc
+)
+target_link_libraries(ostparkmanager PRIVATE
+    ostindimodule
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Concurrent
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Threads::Threads
+    z
+)
+target_compile_definitions(ostparkmanager PRIVATE PARKMANAGER_MODULE)
+
+# Monitor module
+add_library(ostmonitor SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitor/monitor.qrc
+)
+target_link_libraries(ostmonitor PRIVATE
+    ostindimodule
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Concurrent
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Threads::Threads
+    z
+)
+target_compile_definitions(ostmonitor PRIVATE MONITOR_MODULE)
+
+# Meteo module
+add_library(ostmeteo SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/meteo/meteo.qrc
+)
+target_link_libraries(ostmeteo PRIVATE
+    ostindimodule
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Concurrent
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Threads::Threads
+    z
+)
+target_compile_definitions(ostmeteo PRIVATE METEO_MODULE)
 
 install(TARGETS
     ostserver
@@ -571,9 +571,9 @@ install(TARGETS
     ostallsky
     ostplanner
     ostpolar
-#    ostparkmanager
-#    ostmonitor
-#    ostmeteo
+    ostparkmanager
+    ostmonitor
+    ostmeteo
     RUNTIME DESTINATION "/usr/bin"     COMPONENT Runtime
     LIBRARY DESTINATION "/usr/lib"     COMPONENT Runtime
     PUBLIC_HEADER DESTINATION "/usr/include/ost" COMPONENT Development

--- a/libs/basemodule.cpp
+++ b/libs/basemodule.cpp
@@ -68,6 +68,7 @@ void Basemodule::onExternalEventRoot(OST::ExtEvent event)
         case OST::ExtEvType::CS:
         case OST::ExtEvType::PL:
         case OST::ExtEvType::PS:
+        case OST::ExtEvType::QY:
             return;
         default:
         {
@@ -156,6 +157,23 @@ bool Basemodule::onExternalEventBase(OST::ExtEvent event)
             logError("Error saving profile %1", {o["profile"].toString()});
             return false;
         }
+    }
+
+    if (event.ev == OST::ExtEvType::QY)
+    {
+        if (!o.contains("query"))
+        {
+            logError("Basemodule::onExternalEventBase - invalid query data content - %1", {OST::ExtEvToString(event.ev)});
+            return false;
+        }
+        QString queryName = o["query"].toString();
+        QVariantMap params = o["params"].toObject().toVariantMap();
+        QVariantMap result = this->onModuleQuery(queryName, params);
+        QVariantMap answer;
+        answer["query"]  = queryName;
+        answer["result"] = result;
+        emit moduleEvent(OST::EvType::qa, answer, nullptr, nullptr, nullptr, this);
+        return true;
     }
 
     /* property target operations */
@@ -299,6 +317,14 @@ void Basemodule::onExternalEvent(OST::ExtEvent event)
 {
     Q_UNUSED(event);
     // Empty by default - custom modules will override this
+}
+
+QVariantMap Basemodule::onModuleQuery(const QString &queryName, const QVariantMap &params)
+{
+    Q_UNUSED(queryName);
+    Q_UNUSED(params);
+    // Empty by default - custom modules override this to answer the query names they support
+    return QVariantMap();
 }
 
 void Basemodule::onAfterInit(void)
@@ -703,6 +729,20 @@ void Basemodule::otherModuleRequestProfileLoad(QString mod, QString profile)
     event.mod = mod;
     QJsonObject m, M, p;
     p["profile"] = profile;
+    m[mod] = p;
+    M["m"] = m;
+    event.data = M;
+    emit interModuleRequest(event);
+};
+void Basemodule::otherModuleQuery(QString mod, QString queryName, QVariantMap params)
+{
+    OST::ExtEvent event;
+    //{"QY":{"m":{"seq":{"query":"profileduration","params":{"profile":"default"}}}}}
+    event.ev = OST::ExtEvType::QY;
+    event.mod = mod;
+    QJsonObject m, M, p;
+    p["query"] = queryName;
+    p["params"] = QJsonObject::fromVariantMap(params);
     m[mod] = p;
     M["m"] = m;
     event.data = M;

--- a/libs/basemodule.h
+++ b/libs/basemodule.h
@@ -130,10 +130,25 @@ class Basemodule : public DBManager
          */
         virtual void onExternalEvent(OST::ExtEvent event);
 
+        /**
+         * @brief Answer a named query from another module (generic RPC-style hook)
+         *
+         * Override this in modules that expose derived/computed information other
+         * modules may need without loading a profile or duplicating properties
+         * (e.g. "what would the theoretical duration of profile X be").
+         * Empty by default - custom modules override this to answer the query
+         * names they support, returning an empty map for anything else.
+         *
+         * The answer is sent back to the asking module as a moduleEvent of type
+         * OST::EvType::qa, received through its onOtherModuleEvent.
+         */
+        virtual QVariantMap onModuleQuery(const QString &queryName, const QVariantMap &params);
+
         void otherModuleSetValue(QString mod, QString prop, QString elt, QVariant value);
         void otherModuleRequestPropertyDump(QString mod, QString prop);
         void otherModuleRequestProfileLoad(QString mod, QString profile);
         void otherModuleCreateLine(QString mod, QString prop, QVariantMap values);
+        void otherModuleQuery(QString mod, QString queryName, QVariantMap params);
         bool giveMeAState();
         bool giveMeAParms();
 

--- a/libs/model/element/common.h
+++ b/libs/model/element/common.h
@@ -240,6 +240,7 @@ enum class EvType
     fl,        /*!< profile loaded */
     fc,        /*!< profile changed */
     uc,        /*!< update controller data */
+    qa,        /*!< answer to another module's query (see onModuleQuery) */
     xx,        /*!< client ping acknowledgement */
 };
 inline QString EvToString(EvType ev)
@@ -294,6 +295,8 @@ inline QString EvToString(EvType ev)
             return "fc-profile changed";
         case OST::EvType::uc:
             return "uc-update controller data";
+        case OST::EvType::qa:
+            return "qa-query answer";
         default:
             return "unknown:" + QString::number(static_cast<int>(ev));
     }
@@ -311,6 +314,7 @@ enum class ExtEvType
     MK,        /*!< Kill module */
     PL,        /*!< Load profile */
     PS,        /*!< Save profile */
+    QY,        /*!< Query another module (generic request/answer, see onModuleQuery) */
     CL,        /*!< Load configuration */
     CS,        /*!< Save configuration*/
     SV,        /*!< set a value of a property */
@@ -360,6 +364,8 @@ inline QString ExtEvToString(ExtEvType ev)
             return "PL";
         case OST::ExtEvType::PS:
             return "PS";
+        case OST::ExtEvType::QY:
+            return "QY";
         case OST::ExtEvType::CL:
             return "CL";
         case OST::ExtEvType::CS:

--- a/libs/model/element/elementprg.cpp
+++ b/libs/model/element/elementprg.cpp
@@ -35,7 +35,7 @@ void ElementPrg::setDynLabel(const QString &s, const bool &emitEvent)
 }
 QString ElementPrg::dynLabel()
 {
-    return mDynLabel;
+    return value().dynlabel;
 }
 PrgType ElementPrg::prgType()
 {

--- a/libs/model/element/elementprg.h
+++ b/libs/model/element/elementprg.h
@@ -183,7 +183,6 @@ class ElementPrg: public ElementTemplateNotNumeric<PrgData>
 
     private:
         PrgType mType = spinner;      /*!< Progress indicator type (spinner or progressbar) */
-        QString mDynLabel = "";       /*!< Dynamic status label text */
 
 };
 

--- a/libs/utils/modulejsondumper.cpp
+++ b/libs/utils/modulejsondumper.cpp
@@ -14,6 +14,13 @@ QJsonValue ModuleJsonDumper(EvType evt, QVariant data, ElementBase *elt, Propert
         return result;
     }
 
+    /* generic query answer (see Basemodule::onModuleQuery) */
+    if (evt == EvType::qa)
+    {
+        result["q"] = QJsonObject::fromVariantMap(data.toMap());
+        return result;
+    }
+
     /* global dumps & profiles events : profile data is required */
     if (evt == EvType::aa || evt == EvType::am  || evt == EvType::fs   || evt == EvType::fl   || evt == EvType::fc )
     {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -507,6 +507,7 @@ void Controller::onModuleEvent(OST::EvType evt, QVariant data, OST::ElementBase*
         case OST::EvType::fl: // "fl-profile loaded"
         case OST::EvType::fc: // "fc-profile changed"
         case OST::EvType::uc: // "uc-update controller data"
+        case OST::EvType::qa: // "qa-query answer"
         {
             v = OST::ModuleJsonDumper(evt, data, elt, prp, lov, static_cast<Basemodule*>(mod));
             break;

--- a/src/modules/navigator/navigator.cpp
+++ b/src/modules/navigator/navigator.cpp
@@ -593,6 +593,7 @@ void Navigator::correctOffset(double solvedRA, double solvedDEC)
 }
 void Navigator::syncMountIfNeeded(double solvedRA, double solvedDEC)
 {
+    if (!getBool("centeringparams", "syncafter")) return;
 
     setStateEvent(OST::Busy, "synchronise", "syncrequest", "Sync requested");
     // Get mount device
@@ -630,7 +631,7 @@ void Navigator::syncMountIfNeeded(double solvedRA, double solvedDEC)
 
     logInfo("Mount successfully synchronized with solved field");
 
-
+    setStateEvent(OST::Ok, "ready", "syncdone", "Mount synchronized");
 }
 void Navigator::addTargeToPlanner()
 {

--- a/src/modules/planner/planner.cpp
+++ b/src/modules/planner/planner.cpp
@@ -198,6 +198,7 @@ void Planner::startPlanner()
     }
 
     mCurrentLine = 0;
+    mSkipCounts.clear();
     startLine();
 
 }
@@ -259,20 +260,7 @@ void Planner::sequenceComplete()
     getEltPrg("planning", "progress")->setPrgValue(100, false);
     getProperty("planning")->updateLine(mCurrentLine);
 
-
-    mCurrentLine++;
-    if (getProperty("planning")->getGrid().count() <= mCurrentLine)
-    {
-        logInfo("Planning completed");
-        // update global status
-        getEltPrg("progress", "global")->setPrgValue(100, true);
-        getEltPrg("progress", "global")->setDynLabel("Finished", true);
-        mIsRunning = false;
-        return;
-    }
-
-    startLine();
-
+    advanceToNextLine();
 }
 void Planner::navigatorComplete()
 {
@@ -353,24 +341,49 @@ void Planner::proceedToSlew()
 
 void Planner::skipLine(const QString &reason)
 {
-    logWarning("Skipping target %1: %2", {getString("planning", "object"), reason});
+    int attempts    = ++mSkipCounts[mCurrentLine];
+    int maxRetries  = getInt("visibility", "maxretries");
 
-    getProperty("planning")->fetchLine(mCurrentLine);
-    getEltPrg("planning", "progress")->setDynLabel("Skipped: " + reason, false);
-    getEltPrg("planning", "progress")->setPrgValue(0, false);
-    getProperty("planning")->updateLine(mCurrentLine);
-
-    mCurrentLine++;
-    if (getProperty("planning")->getGrid().count() <= mCurrentLine)
+    if (attempts >= maxRetries)
     {
-        logInfo("Planning completed");
-        getEltPrg("progress", "global")->setPrgValue(100, true);
-        getEltPrg("progress", "global")->setDynLabel("Finished", true);
-        mIsRunning = false;
-        return;
+        logWarning("Giving up on target %1 after %2 attempts: %3", {getString("planning", "object"), QString::number(attempts), reason});
+        getProperty("planning")->fetchLine(mCurrentLine);
+        getEltPrg("planning", "progress")->setDynLabel("Failed: " + reason, false);
+        getEltPrg("planning", "progress")->setPrgValue(0, false);
+        getProperty("planning")->updateLine(mCurrentLine);
+    }
+    else
+    {
+        logWarning("Skipping target %1 (attempt %2/%3): %4", {getString("planning", "object"), QString::number(attempts), QString::number(maxRetries), reason});
+        getProperty("planning")->fetchLine(mCurrentLine);
+        getEltPrg("planning", "progress")->setDynLabel("Skipped: " + reason, false);
+        getEltPrg("planning", "progress")->setPrgValue(0, false);
+        getProperty("planning")->updateLine(mCurrentLine);
     }
 
-    startLine();
+    advanceToNextLine();
+}
+
+void Planner::advanceToNextLine()
+{
+    int count = getProperty("planning")->getGrid().count();
+    for (int i = 1; i <= count; i++)
+    {
+        int idx = (mCurrentLine + i) % count;
+        getProperty("planning")->fetchLine(idx);
+        QString label = getEltPrg("planning", "progress")->dynLabel();
+        if (label != "Finished" && !label.startsWith("Failed"))
+        {
+            mCurrentLine = idx;
+            startLine();
+            return;
+        }
+    }
+
+    logInfo("Planning completed");
+    getEltPrg("progress", "global")->setPrgValue(100, true);
+    getEltPrg("progress", "global")->setDynLabel("Finished", true);
+    mIsRunning = false;
 }
 
 bool Planner::checkVisibility(double ra, double dec, double durationSeconds, QString &reason)

--- a/src/modules/planner/planner.cpp
+++ b/src/modules/planner/planner.cpp
@@ -262,6 +262,21 @@ void Planner::sequenceComplete()
 
     advanceToNextLine();
 }
+
+void Planner::sequenceCancelled()
+{
+    mWaitingSequence = false;
+    mWaitingNavigator = false;
+
+    logWarning("Sequence for target %1 was cancelled - moving on", {getString("planning", "object")});
+
+    getProperty("planning")->fetchLine(mCurrentLine);
+    getEltPrg("planning", "progress")->setDynLabel("Cancelled", false);
+    getEltPrg("planning", "progress")->setPrgValue(0, false);
+    getProperty("planning")->updateLine(mCurrentLine);
+
+    advanceToNextLine();
+}
 void Planner::navigatorComplete()
 {
     mWaitingNavigator = false;
@@ -372,7 +387,7 @@ void Planner::advanceToNextLine()
         int idx = (mCurrentLine + i) % count;
         getProperty("planning")->fetchLine(idx);
         QString label = getEltPrg("planning", "progress")->dynLabel();
-        if (label != "Finished" && !label.startsWith("Failed"))
+        if (label != "Finished" && label != "Cancelled" && !label.startsWith("Failed"))
         {
             mCurrentLine = idx;
             startLine();
@@ -488,6 +503,11 @@ void Planner::onOtherModuleEvent(OST::EvType ev, QString mod, QString prp, QStri
         QString e = o["event"].toString();
         QString ed = o["eventdescription"].toString();
         //logDebug("catching signals event from %6 : %1 %2 %3 %4 %5", {OST::EvToString(ev), s, sd, e, ed, mod});
+        if (OST::IntToState(s) == OST::Ok && sd == "ready" && e == "abortdone")
+        {
+            sequenceCancelled();
+            return;
+        }
         if (OST::IntToState(s) == OST::Ok && sd == "ready")
         {
             sequenceComplete();

--- a/src/modules/planner/planner.cpp
+++ b/src/modules/planner/planner.cpp
@@ -1,5 +1,9 @@
 #include "planner.h"
 #include "version.cc"
+#include <libnova/julian_day.h>
+#include <libnova/transform.h>
+#include <libnova/lunar.h>
+#include <libnova/angular_separation.h>
 
 /**
  * @brief Required export function for dynamic module loading
@@ -212,6 +216,7 @@ void Planner::abortPlanner()
     mIsRunning = false;
     mWaitingSequence = false;
     mWaitingNavigator = false;
+    mWaitingDuration = false;
 
     logInfo("Operation aborted");
 
@@ -301,6 +306,25 @@ void Planner::startLine()
 
     // update line status
     getProperty("planning")->fetchLine(mCurrentLine);
+    getEltPrg("planning", "progress")->setDynLabel("Checking visibility", false);
+    getEltPrg("planning", "progress")->setPrgValue(0, false);
+    getProperty("planning")->updateLine(mCurrentLine);
+
+    logInfo("Checking visibility for target %1", {getString("planning", "object")});
+
+    mWaitingSequence  = false;
+    mWaitingNavigator = false;
+    mWaitingDuration   = true;
+
+    // Ask the sequencer how long the requested profile would theoretically take,
+    // so the visibility check covers the whole sequence, not just this instant.
+    otherModuleQuery(getString("slaves", "sequencemodule"), "profileduration",
+    {{"profile", getString("planning", "profile")}});
+}
+
+void Planner::proceedToSlew()
+{
+    getProperty("planning")->fetchLine(mCurrentLine);
     getEltPrg("planning", "progress")->setDynLabel("Slewing", false);
     getEltPrg("planning", "progress")->setPrgValue(0, false);
     getProperty("planning")->updateLine(mCurrentLine);
@@ -326,11 +350,99 @@ void Planner::startLine()
     // Ask navigator to slew to target
     otherModuleSetValue( getString("slaves", "navigatormodule"), "actions", "gototarget", true);
 }
+
+void Planner::skipLine(const QString &reason)
+{
+    logWarning("Skipping target %1: %2", {getString("planning", "object"), reason});
+
+    getProperty("planning")->fetchLine(mCurrentLine);
+    getEltPrg("planning", "progress")->setDynLabel("Skipped: " + reason, false);
+    getEltPrg("planning", "progress")->setPrgValue(0, false);
+    getProperty("planning")->updateLine(mCurrentLine);
+
+    mCurrentLine++;
+    if (getProperty("planning")->getGrid().count() <= mCurrentLine)
+    {
+        logInfo("Planning completed");
+        getEltPrg("progress", "global")->setPrgValue(100, true);
+        getEltPrg("progress", "global")->setDynLabel("Finished", true);
+        mIsRunning = false;
+        return;
+    }
+
+    startLine();
+}
+
+bool Planner::checkVisibility(double ra, double dec, double durationSeconds, QString &reason)
+{
+    ln_lnlat_posn observer;
+    observer.lat = getFloat("location", "lat");
+    observer.lng = getFloat("location", "lon");
+
+    ln_equ_posn target;
+    target.ra  = ra * 15.0; // stored in hours, libnova expects degrees
+    target.dec = dec;
+
+    double jdNow = ln_get_julian_from_sys();
+    double jdEnd = jdNow + (durationSeconds / 86400.0);
+
+    ln_hrz_posn hrzNow, hrzEnd;
+    ln_get_hrz_from_equ(&target, &observer, jdNow, &hrzNow);
+    ln_get_hrz_from_equ(&target, &observer, jdEnd,  &hrzEnd);
+
+    double minElevation = getFloat("visibility", "minelevation");
+    double worstAlt = qMin(hrzNow.alt, hrzEnd.alt);
+    if (worstAlt < minElevation)
+    {
+        reason = QString("elevation %1° below minimum %2°")
+                 .arg(worstAlt, 0, 'f', 1)
+                 .arg(minElevation, 0, 'f', 1);
+        return false;
+    }
+
+    ln_equ_posn moonEqu;
+    ln_get_lunar_equ_coords(jdNow, &moonEqu);
+    double illumination = ln_get_lunar_disk(jdNow) * 100.0;
+    double separation    = ln_get_angular_separation(&target, &moonEqu);
+
+    double illumThreshold = getFloat("visibility", "moonilluminationthreshold");
+    double sepThreshold   = getFloat("visibility", "moonseparationthreshold");
+    if (illumination > illumThreshold && separation < sepThreshold)
+    {
+        reason = QString("moon %1% illuminated, only %2° away")
+                 .arg(illumination, 0, 'f', 0)
+                 .arg(separation, 0, 'f', 1);
+        return false;
+    }
+
+    return true;
+}
 void Planner::onOtherModuleEvent(OST::EvType ev, QString mod, QString prp, QString elt, QVariant data, int line)
 {
     if (mod != getString("slaves", "navigatormodule") && mod != getString("slaves", "sequencemodule") ) return;
 
     //logDebug("Planner::onOtherModuleEvent2 mod=%1 ev=%2 prop=%3 elt=%4 data=%5", {mod, OST::EvToString(ev), prp, elt, data});
+
+    if (mod == getString("slaves", "sequencemodule") && ev == OST::EvType::qa && mWaitingDuration)
+    {
+        QJsonObject q = data.toJsonValue().toObject()["q"].toObject();
+        if (q["query"].toString() == "profileduration")
+        {
+            mWaitingDuration = false;
+            double seconds = q["result"].toObject()["seconds"].toDouble();
+
+            QString reason;
+            if (checkVisibility(getFloat("planning", "ra"), getFloat("planning", "dec"), seconds, reason))
+            {
+                proceedToSlew();
+            }
+            else
+            {
+                skipLine(reason);
+            }
+        }
+        return;
+    }
 
     if (mod == getString("slaves", "navigatormodule") && ev == OST::EvType::ea && prp == "signals"  && mWaitingNavigator)
     {

--- a/src/modules/planner/planner.h
+++ b/src/modules/planner/planner.h
@@ -67,7 +67,7 @@ class Planner : public IndiModule
         void proceedToSlew();
 
         /**
-         * @brief Mark the current line as skipped and move on to the next one
+         * @brief Mark the current line as skipped (or failed, past the retry limit) and move on
          */
         void skipLine(const QString &reason);
 
@@ -77,6 +77,13 @@ class Planner : public IndiModule
          * @param reason filled with a human-readable explanation when returning false
          */
         bool checkVisibility(double ra, double dec, double durationSeconds, QString &reason);
+
+        /**
+         * @brief Move on to the next line still worth attempting (not Finished/Failed),
+         * wrapping around the grid so skipped lines get retried once every other line
+         * has had its turn. Ends the planning when nothing is left to attempt.
+         */
+        void advanceToNextLine();
 
 
         // Example internal state variables
@@ -93,6 +100,9 @@ class Planner : public IndiModule
 
         // Current line
         int mCurrentLine;
+
+        // Number of times each line (by grid index) has been skipped this run
+        QMap<int, int> mSkipCounts;
 
 };
 

--- a/src/modules/planner/planner.h
+++ b/src/modules/planner/planner.h
@@ -57,9 +57,26 @@ class Planner : public IndiModule
         void navigatorComplete();
 
         /**
-         * @brief Start current planning line
+         * @brief Start current planning line: kicks off the visibility check
          */
         void startLine();
+
+        /**
+         * @brief Slew and start the sequence, once the line has passed the visibility check
+         */
+        void proceedToSlew();
+
+        /**
+         * @brief Mark the current line as skipped and move on to the next one
+         */
+        void skipLine(const QString &reason);
+
+        /**
+         * @brief Check whether a target stays above the configured minimum elevation
+         * for the whole estimated sequence duration, and clear of the moon.
+         * @param reason filled with a human-readable explanation when returning false
+         */
+        bool checkVisibility(double ra, double dec, double durationSeconds, QString &reason);
 
 
         // Example internal state variables
@@ -70,6 +87,9 @@ class Planner : public IndiModule
 
         // Waiting navigator
         bool mWaitingNavigator = false ;
+
+        // Waiting for the sequencer's profileduration query answer
+        bool mWaitingDuration = false ;
 
         // Current line
         int mCurrentLine;

--- a/src/modules/planner/planner.h
+++ b/src/modules/planner/planner.h
@@ -52,6 +52,12 @@ class Planner : public IndiModule
         void sequenceComplete();
 
         /**
+         * @brief What to do when the sequence was manually cancelled rather than
+         * completed - move on to the next line without marking this one Finished
+         */
+        void sequenceCancelled();
+
+        /**
          * @brief What to do after navigator is completed
          */
         void navigatorComplete();

--- a/src/modules/planner/planner.json
+++ b/src/modules/planner/planner.json
@@ -83,6 +83,15 @@
           "value": 30,
           "order": 3,
           "hint": "Rejected only if the target is closer than this AND the moon illumination exceeds the threshold above"
+      },
+      "maxretries": {
+          "type": "int",
+          "label": "Max retries before giving up",
+          "autoupdate": true,
+          "directedit": true,
+          "value": 3,
+          "order": 4,
+          "hint": "A line that fails the visibility/moon check this many times is marked Failed and is no longer retried"
       }
     }
   },

--- a/src/modules/planner/planner.json
+++ b/src/modules/planner/planner.json
@@ -49,6 +49,43 @@
       }
     }
   },
+  "visibility": {
+    "label": "Visibility constraints",
+    "permission": 2,
+    "devcat": "Visibility",
+    "group": "",
+    "order": "060",
+    "hasprofile": true,
+    "e": {
+      "minelevation": {
+          "type": "float",
+          "label": "Minimum elevation (°)",
+          "autoupdate": true,
+          "directedit": true,
+          "value": 20,
+          "order": 1,
+          "hint": "Target must stay above this elevation for the whole estimated sequence duration, otherwise the line is skipped"
+      },
+      "moonilluminationthreshold": {
+          "type": "float",
+          "label": "Moon illumination threshold (%)",
+          "autoupdate": true,
+          "directedit": true,
+          "value": 50,
+          "order": 2,
+          "hint": "Moon avoidance only applies when the moon's illuminated fraction is above this percentage"
+      },
+      "moonseparationthreshold": {
+          "type": "float",
+          "label": "Moon separation threshold (°)",
+          "autoupdate": true,
+          "directedit": true,
+          "value": 30,
+          "order": 3,
+          "hint": "Rejected only if the target is closer than this AND the moon illumination exceeds the threshold above"
+      }
+    }
+  },
   "planning": {
     "label": "Planning",
     "permission": 2,

--- a/src/modules/sequencer/sequencer.cpp
+++ b/src/modules/sequencer/sequencer.cpp
@@ -804,6 +804,42 @@ void Sequencer::recomputeSequenceTotals()
     getEltString("progress", "theoreticalremaining")->setValue(formatDuration(remaining), true);
 }
 
+QVariantMap Sequencer::onModuleQuery(const QString &queryName, const QVariantMap &params)
+{
+    if (queryName == "profileduration")
+    {
+        // Peek at a stored profile's "sequence" grid without loading it,
+        // so this can be asked about any profile regardless of what is
+        // currently active (e.g. by the planner, before starting a line).
+        double totalSeconds = 0.0;
+        QJsonObject obj;
+        if (getDbProfile(getClassName(), params["profile"].toString(), obj))
+        {
+            QJsonObject seqProp = obj["p"].toObject()["sequence"].toObject();
+            QJsonArray  headers = seqProp["gridheaders"].toArray();
+            QJsonArray  grid    = seqProp["grid"].toArray();
+
+            int ci = -1, ei = -1;
+            for (int i = 0; i < headers.size(); i++)
+            {
+                if (headers[i].toString() == "count")    ci = i;
+                if (headers[i].toString() == "exposure") ei = i;
+            }
+
+            if (ci != -1 && ei != -1)
+            {
+                for (const QJsonValue &vline : grid)
+                {
+                    QJsonArray line = vline.toArray();
+                    totalSeconds += line[ci].toInt() * line[ei].toDouble();
+                }
+            }
+        }
+        return { {"seconds", totalSeconds} };
+    }
+    return Basemodule::onModuleQuery(queryName, params);
+}
+
 void Sequencer::setupOutputFolder()
 {
     QDir dir;

--- a/src/modules/sequencer/sequencer.h
+++ b/src/modules/sequencer/sequencer.h
@@ -31,6 +31,7 @@ class MODULE_INIT Sequencer: public IndiModule
 
     protected:
         void onExternalEvent(OST::ExtEvent event) override;
+        QVariantMap onModuleQuery(const QString &queryName, const QVariantMap &params) override;
 
     public slots:
         void onOtherModuleEvent(OST::EvType ev, QString mod, QString prp, QString elt, QVariant data, int line) override;


### PR DESCRIPTION
Adds a generic inter-module query mechanism (onModuleQuery) so any module 
 can answer arbitrary named queries from another without a dedicated 
 property per need. The planner uses it to ask the sequencer for a 
 profile's theoretical duration before committing to a target. 

 - Skips targets that don't stay above a configurable minimum elevation 
   for the whole estimated sequence duration, or that are too close to 
   an illuminated moon (two independent thresholds) 
 - Retries skipped lines in a loop around the grid instead of ending the 
   plan after one pass, with a bounded retry count (Failed once exceeded) 
 - Distinguishes a manually cancelled sequence (Cancelled) from a normal 
   completion (Finished), so it isn't mistaken for success 
 - Fixes ElementPrg::dynLabel(), which always returned an empty string 
   (unrelated latent bug surfaced by the retry loop's state checks) 
 - Fixes the navigator staying Busy after centering when mount sync is 
   disabled, and not respecting the sync setting at all